### PR TITLE
Make terminal optional for spinner

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ documentation = "http://neikos.me/spinner/spinner/"
 
 [dependencies]
 term = "0.6.1"
-ansi_term = "0.7"
+ansi_term = "0.12.1"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To use Spinner simply add it to your `Cargo.toml`
 
 ```toml
 [dependencies.spinner]
-version = "0.3"
+version = "0.5"
 ```
 
 Usage

--- a/examples/complex_menu.rs
+++ b/examples/complex_menu.rs
@@ -20,7 +20,7 @@ fn main() {
     let tip_p = results.pop().unwrap().get_int().unwrap();
     let bill = results.pop().unwrap().get_float().unwrap();
 
-    let tip = bill * (tip_p as f64/100f64);
+    let tip = bill * (tip_p as f64 / 100f64);
     let total = bill + tip;
 
     if ppl < 1 {
@@ -29,6 +29,5 @@ fn main() {
     }
 
     println!("{} pay {}, the tip is {}", if ppl > 1 { "Each of you" } else { "You" },
-             total/ppl as f64, tip);
-
+             total / ppl as f64, tip);
 }

--- a/examples/complex_menu.rs
+++ b/examples/complex_menu.rs
@@ -1,17 +1,24 @@
 extern crate spinner;
 
+use spinner::menu::{MenuOptional, MenuType, MenuValue};
 use spinner::{Menu, MenuOption};
-use spinner::menu::{MenuType, MenuValue, MenuOptional};
 
 fn main() {
     println!("Welcome to the Rust TipCalculator MKI");
     let m = Menu::new(vec![
-        MenuOption("Bill".into(), MenuType::Float,
-                   MenuOptional::Required, None),
-        MenuOption("Tip Percentage (eg. 10 for 10%)".into(), MenuType::Integer,
-                   MenuOptional::Required, Some(MenuValue::Integer(10))),
-        MenuOption("Number of People".into(), MenuType::Integer,
-                   MenuOptional::Required, Some(MenuValue::Integer(1))),
+        MenuOption("Bill".into(), MenuType::Float, MenuOptional::Required, None),
+        MenuOption(
+            "Tip Percentage (eg. 10 for 10%)".into(),
+            MenuType::Integer,
+            MenuOptional::Required,
+            Some(MenuValue::Integer(10)),
+        ),
+        MenuOption(
+            "Number of People".into(),
+            MenuType::Integer,
+            MenuOptional::Required,
+            Some(MenuValue::Integer(1)),
+        ),
     ]);
 
     let mut results = m.display();
@@ -28,6 +35,10 @@ fn main() {
         return;
     }
 
-    println!("{} pay {}, the tip is {}", if ppl > 1 { "Each of you" } else { "You" },
-             total / ppl as f64, tip);
+    println!(
+        "{} pay {}, the tip is {}",
+        if ppl > 1 { "Each of you" } else { "You" },
+        total / ppl as f64,
+        tip
+    );
 }

--- a/examples/complex_spinner.rs
+++ b/examples/complex_spinner.rs
@@ -1,16 +1,20 @@
 extern crate spinner;
 
-use std::time::Duration;
 use std::thread;
+use std::time::Duration;
 
 use spinner::SpinnerBuilder;
 
 fn main() {
-    let sp = SpinnerBuilder::new("Long Running op!".into()).
-        format(|sp, status| {
-            format!("{spin} -- Currently working on: \'{status}\' -- {spin}",
-                    spin = sp, status = status)
-        }).start();
+    let sp = SpinnerBuilder::new("Long Running op!".into())
+        .format(|sp, status| {
+            format!(
+                "{spin} -- Currently working on: \'{status}\' -- {spin}",
+                spin = sp,
+                status = status
+            )
+        })
+        .start();
     thread::sleep(Duration::from_millis(2000));
     sp.message("Updating...".into());
     sp.update("Fixing things...".into());

--- a/examples/complex_spinner.rs
+++ b/examples/complex_spinner.rs
@@ -7,7 +7,7 @@ use spinner::SpinnerBuilder;
 
 fn main() {
     let sp = SpinnerBuilder::new("Long Running op!".into()).
-        format(|sp, status|{
+        format(|sp, status| {
             format!("{spin} -- Currently working on: \'{status}\' -- {spin}",
                     spin = sp, status = status)
         }).start();

--- a/examples/kirby_spinner.rs
+++ b/examples/kirby_spinner.rs
@@ -1,13 +1,15 @@
 extern crate spinner;
 
-use std::time::Duration;
 use std::thread;
+use std::time::Duration;
 
 use spinner::{SpinnerBuilder, DANCING_KIRBY};
 
 fn main() {
     let sp = SpinnerBuilder::new("Long Running op!".into())
-        .spinner(DANCING_KIRBY.to_vec()).step(Duration::from_millis(500)).start();
+        .spinner(DANCING_KIRBY.to_vec())
+        .step(Duration::from_millis(500))
+        .start();
 
     thread::sleep(Duration::from_millis(3000));
     sp.message("Updating...".into());

--- a/examples/kirby_spinner.rs
+++ b/examples/kirby_spinner.rs
@@ -1,4 +1,3 @@
-
 extern crate spinner;
 
 use std::time::Duration;

--- a/examples/simple_menu.rs
+++ b/examples/simple_menu.rs
@@ -1,14 +1,34 @@
 extern crate spinner;
 
+use spinner::menu::{MenuOptional, MenuType, MenuValue};
 use spinner::{Menu, MenuOption};
-use spinner::menu::{MenuType, MenuValue, MenuOptional};
 
 fn main() {
     let m = Menu::new(vec![
-        MenuOption("First Name".into(), MenuType::Text, MenuOptional::Required, None),
-        MenuOption("Last Name".into(), MenuType::Text, MenuOptional::Optional, None),
-        MenuOption("Age".into(), MenuType::Integer, MenuOptional::Required, Some(MenuValue::Integer(1))),
-        MenuOption("How much Ketchup?".into(), MenuType::Float, MenuOptional::Required, None),
+        MenuOption(
+            "First Name".into(),
+            MenuType::Text,
+            MenuOptional::Required,
+            None,
+        ),
+        MenuOption(
+            "Last Name".into(),
+            MenuType::Text,
+            MenuOptional::Optional,
+            None,
+        ),
+        MenuOption(
+            "Age".into(),
+            MenuType::Integer,
+            MenuOptional::Required,
+            Some(MenuValue::Integer(1)),
+        ),
+        MenuOption(
+            "How much Ketchup?".into(),
+            MenuType::Float,
+            MenuOptional::Required,
+            None,
+        ),
     ]);
 
     let results = m.display();

--- a/examples/simple_spinner.rs
+++ b/examples/simple_spinner.rs
@@ -1,7 +1,7 @@
 extern crate spinner;
 
-use std::time::Duration;
 use std::thread;
+use std::time::Duration;
 
 use spinner::SpinnerBuilder;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,6 @@ impl Spinner {
                     };
                 }
 
-                let mut t = term::stdout().unwrap();
 
                 if let Some(m) = msg {
                     println!("\n{}", m);
@@ -160,9 +159,11 @@ impl Spinner {
 
                 if should_disc{ break; }
 
+                if let Some(mut t) = term::stdout() {
+                    t.carriage_return().unwrap();
+                    t.delete_line().unwrap();
+                }
 
-                t.carriage_return().unwrap();
-                t.delete_line().unwrap();
                 if let Some(ref cl) = sp.custom_out {
                     print!("{}", cl(i, &sp.status[..]));
                 } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ enum SpinnerMessage {
     Message(String),
 }
 
-type FormatFn = Fn(&str, &str) -> String + Send + 'static;
+type FormatFn = dyn Fn(&str, &str) -> String + Send + 'static;
 
 /// A possible string for the spinner, check out the kirby example for a
 /// possible use case.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@ use std::time::Duration;
 #[derive(Debug)]
 enum SpinnerMessage {
     Status(String),
-    Message(String)
+    Message(String),
 }
 
 type FormatFn = Fn(&str, &str) -> String + Send + 'static;
@@ -106,14 +106,14 @@ type FormatFn = Fn(&str, &str) -> String + Send + 'static;
 /// A possible string for the spinner, check out the kirby example for a
 /// possible use case.
 pub static DANCING_KIRBY: [&'static str; 8] = [
-"(>'-')>",
-"<('-'<)",
-"^('-')^",
-"<('-'<)",
-"(>'-')>",
-"<('-'<)",
-"^('-')^",
-"<('-'<)"
+    "(>'-')>",
+    "<('-'<)",
+    "^('-')^",
+    "<('-'<)",
+    "(>'-')>",
+    "<('-'<)",
+    "^('-')^",
+    "<('-'<)"
 ];
 
 struct Spinner {
@@ -121,13 +121,12 @@ struct Spinner {
     types: Vec<&'static str>,
     rx: Receiver<SpinnerMessage>,
     custom_out: Option<Box<FormatFn>>,
-    step: Duration
+    step: Duration,
 }
 
 impl Spinner {
-
     fn start(sp: Spinner, tx: Sender<SpinnerMessage>) -> SpinnerHandle {
-        let th = thread::spawn(move|| {
+        let th = thread::spawn(move || {
             let mut sp = sp;
             for i in sp.types.iter().cycle() {
                 let mut msg = None;
@@ -138,12 +137,12 @@ impl Spinner {
                             match ms {
                                 SpinnerMessage::Status(st) => {
                                     sp.status = st
-                                },
+                                }
                                 SpinnerMessage::Message(st) => {
                                     msg = Some(st)
                                 }
                             }
-                        },
+                        }
                         Err(TryRecvError::Empty) => break,
                         Err(TryRecvError::Disconnected) => {
                             should_disc = true;
@@ -157,7 +156,7 @@ impl Spinner {
                     println!("\n{}", m);
                 }
 
-                if should_disc{ break; }
+                if should_disc { break; }
 
                 if let Some(mut t) = term::stdout() {
                     t.carriage_return().unwrap();
@@ -207,7 +206,6 @@ impl SpinnerHandle {
                 } else {
                     unreachable!()
                 }
-
             }
         }
     }
@@ -222,7 +220,6 @@ impl SpinnerHandle {
                 } else {
                     unreachable!()
                 }
-
             }
         }
     }
@@ -274,20 +271,19 @@ impl SpinnerBuilder {
     /// the complex_spinner example how this could be used.
     pub fn format<F>(mut self, f: F) -> Self
         where F: Fn(&str, &str) -> String + Send + 'static
-        {
-            self.custom_format = Some(Box::new(f));
-            self
-        }
+    {
+        self.custom_format = Some(Box::new(f));
+        self
+    }
 
     /// Start the thread that takes care of the Spinner and return immediately
     /// allowing you to load or do otherwise operations.
     pub fn start(self) -> SpinnerHandle {
-
         let typ = {
             if let Some(v) = self.spinner {
                 v
             } else {
-                vec!["▁","▃","▄","▅","▆","▇","█","▇","▆","▅","▄","▃"]
+                vec!["▁", "▃", "▄", "▅", "▆", "▇", "█", "▇", "▆", "▅", "▄", "▃"]
             }
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@ impl Spinner {
     fn start(sp: Spinner, tx: Sender<SpinnerMessage>) -> SpinnerHandle {
         let th = thread::spawn(move || {
             let mut sp = sp;
-            for i in sp.types.iter().cycle() {
+            for ttype in sp.types.iter().cycle() {
                 let mut msg = None;
                 let mut should_disc = false;
                 loop {
@@ -164,13 +164,13 @@ impl Spinner {
                 }
 
                 if let Some(ref cl) = sp.custom_out {
-                    print!("{}", cl(i, &sp.status[..]));
+                    print!("{}", cl(ttype, &sp.status[..]));
                 } else {
-                    print!("{} {}", i, sp.status);
+                    print!("{} {}", ttype, sp.status);
                 }
                 {
-                    let x = stdout();
-                    x.lock().flush().unwrap();
+                    let stdout = stdout();
+                    stdout.lock().flush().unwrap();
                 }
                 thread::sleep(sp.step)
             }
@@ -246,7 +246,7 @@ impl SpinnerBuilder {
     /// Create a SpinnerBuilder, giving an original message
     pub fn new(msg: String) -> Self {
         SpinnerBuilder {
-            msg: msg,
+            msg,
             spinner: None,
             custom_format: None,
             step: None,
@@ -279,7 +279,7 @@ impl SpinnerBuilder {
     /// Start the thread that takes care of the Spinner and return immediately
     /// allowing you to load or do otherwise operations.
     pub fn start(self) -> SpinnerHandle {
-        let typ = {
+        let ttypes = {
             if let Some(v) = self.spinner {
                 v
             } else {
@@ -298,9 +298,9 @@ impl SpinnerBuilder {
         let (tx, rx) = channel();
         let sp = Spinner {
             status: self.msg,
-            types: typ,
+            types: ttypes,
             custom_out: self.custom_format,
-            rx: rx,
+            rx,
             step: st,
         };
         Spinner::start(sp, tx)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,12 +74,16 @@
 //! you to put in either `None`, for no default value or `Some<MenuValue>` which
 //! will be used if the user inputs nothing.
 
-#![deny(missing_docs,
-        missing_copy_implementations,
-        trivial_casts, trivial_numeric_casts,
-        unsafe_code,
-        unstable_features,
-        unused_import_braces, unused_qualifications)]
+#![deny(
+    missing_docs,
+    missing_copy_implementations,
+    trivial_casts,
+    trivial_numeric_casts,
+    unsafe_code,
+    unstable_features,
+    unused_import_braces,
+    unused_qualifications
+)]
 
 extern crate ansi_term;
 extern crate term;
@@ -90,8 +94,8 @@ pub mod menu;
 pub use menu::Menu;
 pub use menu::MenuOption;
 
-use std::sync::mpsc::{Sender, Receiver, channel, SendError, TryRecvError};
-use std::io::{Write, stdout};
+use std::io::{stdout, Write};
+use std::sync::mpsc::{channel, Receiver, SendError, Sender, TryRecvError};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
@@ -106,14 +110,7 @@ type FormatFn = dyn Fn(&str, &str) -> String + Send + 'static;
 /// A possible string for the spinner, check out the kirby example for a
 /// possible use case.
 pub static DANCING_KIRBY: [&'static str; 8] = [
-    "(>'-')>",
-    "<('-'<)",
-    "^('-')^",
-    "<('-'<)",
-    "(>'-')>",
-    "<('-'<)",
-    "^('-')^",
-    "<('-'<)"
+    "(>'-')>", "<('-'<)", "^('-')^", "<('-'<)", "(>'-')>", "<('-'<)", "^('-')^", "<('-'<)",
 ];
 
 struct Spinner {
@@ -133,16 +130,10 @@ impl Spinner {
                 let mut should_disc = false;
                 loop {
                     match sp.rx.try_recv() {
-                        Ok(ms) => {
-                            match ms {
-                                SpinnerMessage::Status(st) => {
-                                    sp.status = st
-                                }
-                                SpinnerMessage::Message(st) => {
-                                    msg = Some(st)
-                                }
-                            }
-                        }
+                        Ok(ms) => match ms {
+                            SpinnerMessage::Status(st) => sp.status = st,
+                            SpinnerMessage::Message(st) => msg = Some(st),
+                        },
                         Err(TryRecvError::Empty) => break,
                         Err(TryRecvError::Disconnected) => {
                             should_disc = true;
@@ -151,12 +142,13 @@ impl Spinner {
                     };
                 }
 
-
                 if let Some(m) = msg {
                     println!("\n{}", m);
                 }
 
-                if should_disc { break; }
+                if should_disc {
+                    break;
+                }
 
                 if let Some(mut t) = term::stdout() {
                     t.carriage_return().unwrap();
@@ -270,7 +262,8 @@ impl SpinnerBuilder {
     /// Set the format closure that is to be used by the spinner, check out
     /// the complex_spinner example how this could be used.
     pub fn format<F>(mut self, f: F) -> Self
-        where F: Fn(&str, &str) -> String + Send + 'static
+    where
+        F: Fn(&str, &str) -> String + Send + 'static,
     {
         self.custom_format = Some(Box::new(f));
         self

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -1,9 +1,9 @@
+use std::fmt::{Display, Error as FmtError, Formatter};
 use std::io::{stdin, stdout, Write};
-use std::fmt::{Display, Formatter, Error as FmtError};
 use std::str::FromStr;
 
-use ansi_term::Style;
 use ansi_term::Colour::Red;
+use ansi_term::Style;
 
 /// An enum specifying if a given field is optional or not
 #[derive(Eq, PartialEq, Clone, Copy, Debug)]
@@ -46,14 +46,19 @@ impl Display for MenuValue {
         match self {
             &MenuValue::Text(ref s) => s.fmt(f),
             &MenuValue::Integer(ref s) => s.fmt(f),
-            &MenuValue::Float(ref s) => s.fmt(f)
+            &MenuValue::Float(ref s) => s.fmt(f),
         }
     }
 }
 
 /// An individual MenuOption, check out the crate documentation on how to use it
 #[derive(Clone, Debug)]
-pub struct MenuOption(pub String, pub MenuType, pub MenuOptional, pub Option<MenuValue>);
+pub struct MenuOption(
+    pub String,
+    pub MenuType,
+    pub MenuOptional,
+    pub Option<MenuValue>,
+);
 
 impl MenuOption {
     fn set_string(&mut self, s: String) {
@@ -77,7 +82,10 @@ impl MenuOption {
         match self.3.take() {
             Some(MenuValue::Text(s)) => Some(s),
             None => None,
-            a => panic!("Tried to take a String out of a menu option that is a {:?}", a)
+            a => panic!(
+                "Tried to take a String out of a menu option that is a {:?}",
+                a
+            ),
         }
     }
 
@@ -91,7 +99,10 @@ impl MenuOption {
         match self.3.take() {
             Some(MenuValue::Integer(s)) => Some(s),
             None => None,
-            a => panic!("Tried to take a Integer out of a menu option that is a {:?}", a)
+            a => panic!(
+                "Tried to take a Integer out of a menu option that is a {:?}",
+                a
+            ),
         }
     }
 
@@ -104,15 +115,17 @@ impl MenuOption {
         match self.3.take() {
             Some(MenuValue::Float(s)) => Some(s),
             None => None,
-            a => panic!("Tried to take a Float out of a menu option that is a {:?}", a)
+            a => panic!(
+                "Tried to take a Float out of a menu option that is a {:?}",
+                a
+            ),
         }
     }
-
 
     fn is_optional(&self) -> bool {
         match self.2 {
             MenuOptional::Optional => true,
-            MenuOptional::Required => false
+            MenuOptional::Required => false,
         }
     }
 
@@ -164,9 +177,7 @@ pub struct Menu {
 impl Menu {
     /// Construct a new menu using the given MenuOptions
     pub fn new(i: Vec<MenuOption>) -> Self {
-        Menu {
-            items: i,
-        }
+        Menu { items: i }
     }
 
     /// Consume the menu and return a Vector of MenuOptions with the new values
@@ -177,23 +188,32 @@ impl Menu {
 
         while i < max {
             let ref mut item = self.items[i];
-            print!("{} {}expecting {}: ", Style::new().bold().paint(&item.0[..]), {
-                if let Some(ref s) = item.3 {
-                    format!("({}default: \"{}\") ", {
+            print!(
+                "{} {}expecting {}: ",
+                Style::new().bold().paint(&item.0[..]),
+                {
+                    if let Some(ref s) = item.3 {
+                        format!(
+                            "({}default: \"{}\") ",
+                            {
+                                if item.is_optional() {
+                                    "Optional, ".into()
+                                } else {
+                                    String::new()
+                                }
+                            },
+                            s
+                        )
+                    } else {
                         if item.is_optional() {
-                            "Optional, ".into()
+                            "(Optional) ".into()
                         } else {
                             String::new()
                         }
-                    }, s)
-                } else {
-                    if item.is_optional() {
-                        "(Optional) ".into()
-                    } else {
-                        String::new()
                     }
-                }
-            }, Style::new().italic().paint(item.get_type_name()));
+                },
+                Style::new().italic().paint(item.get_type_name())
+            );
             stdout().flush().unwrap();
             let mut buffer = String::new();
             // TODO: Think of a way to not unwrap here, result?
@@ -201,7 +221,10 @@ impl Menu {
 
             let empty = buffer.chars().all(char::is_whitespace);
             if empty && !item.is_optional() && !item.has_value() {
-                println!("{}", Red.paint("This item is not optional, please enter a value."));
+                println!(
+                    "{}",
+                    Red.paint("This item is not optional, please enter a value.")
+                );
                 continue;
             } else if empty {
                 // We do not remove the default value
@@ -210,7 +233,10 @@ impl Menu {
             }
 
             if item.set(buffer).is_err() {
-                println!("{}", Red.paint("You have entered the wrong type of information."));
+                println!(
+                    "{}",
+                    Red.paint("You have entered the wrong type of information.")
+                );
                 continue;
             }
             i = i + 1;

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -1,4 +1,4 @@
-use std::io::{stdin, stdout, BufRead, Read, Write};
+use std::io::{stdin, stdout, Write};
 use std::fmt::{Display, Formatter, Error as FmtError};
 use std::str::FromStr;
 

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -124,7 +124,7 @@ impl MenuOption {
         match self.1 {
             MenuType::Text => {
                 let m: &[_] = &['\n', '\r'];
-                self.set_string(s.trim_right_matches(m).into());
+                self.set_string(s.trim_end_matches(m).into());
                 Ok(())
             }
             MenuType::Integer => {

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -11,7 +11,7 @@ pub enum MenuOptional {
     /// This will make the field optional
     Optional,
     /// This will make the field required
-    Required
+    Required,
 }
 
 /// An enum specifying the type of information the user should put in.
@@ -25,7 +25,7 @@ pub enum MenuType {
     /// Input should be type Integer
     Integer,
     /// Input should be type Float
-    Float
+    Float,
 }
 
 /// The value of the given menu, when given as an argument to the constructor
@@ -38,7 +38,7 @@ pub enum MenuValue {
     /// The value of an Integer MenuOption
     Integer(i64),
     /// The value of a Float MenuOption
-    Float(f64)
+    Float(f64),
 }
 
 impl Display for MenuValue {
@@ -120,13 +120,13 @@ impl MenuOption {
         self.3.is_some()
     }
 
-    fn set(&mut self, s: String) -> Result<(), ()>{
+    fn set(&mut self, s: String) -> Result<(), ()> {
         match self.1 {
             MenuType::Text => {
                 let m: &[_] = &['\n', '\r'];
                 self.set_string(s.trim_right_matches(m).into());
                 Ok(())
-            },
+            }
             MenuType::Integer => {
                 let try = i64::from_str(s.trim());
                 if try.is_err() {
@@ -134,7 +134,7 @@ impl MenuOption {
                 }
                 self.set_int(try.unwrap());
                 Ok(())
-            },
+            }
             MenuType::Float => {
                 let try = f64::from_str(s.trim());
                 if try.is_err() {
@@ -142,7 +142,7 @@ impl MenuOption {
                 }
                 self.set_float(try.unwrap());
                 Ok(())
-            },
+            }
         }
     }
 

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -174,11 +174,7 @@ impl Menu {
     pub fn display(mut self) -> Vec<MenuOption> {
         let mut i = 0;
         let max = self.items.len();
-        //{
-        //    // Flush stdin, so previous does not get put in here
-        //    let mut b = Vec::new();
-        //    let _ = stdin().read(&mut b).unwrap();
-        //}
+
         while i < max {
             let ref mut item = self.items[i];
             print!("{} {}expecting {}: ", Style::new().bold().paint(&item.0[..]), {


### PR DESCRIPTION
I have an issue where I'm running tests for my library where there's no terminal available. A dependency to this package is causing the tests to fail.

I think this package shouldn't assume there's a terminal available, so I made this PR. The relevant change is in the first commit. The rest of them are simply clean up and fixing warnings.

I ran all the examples under `examples/` and they seem to be fine. I don't know what other way to verify the behavior is the same.

Let me know what you think!